### PR TITLE
Bootstrapping Part 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.ilk
 *.map
 *.exp
+*.lst
 
 # Precompiled Headers
 *.gch
@@ -35,6 +36,7 @@
 *.i*86
 *.x86_64
 *.hex
+*.bin
 
 # Debug files
 *.dSYM/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,52 @@
+
+SRCS= main.c
+CC=arm-none-eabi-gcc
+OBJCOPY=arm-none-eabi-objcopy
+OBJDUMP=arm-none-eabi-objdump
+SIZE=arm-none-eabi-size
+PROJECT=jmos
+
+## General compiler flags ##
+CFLAGS = -Wall -Werror -std=c99 -g -Tjmos-stm32-link.ld
+CFLAGS += -ffunction-sections -fdata-sections 
+CFLAGS += -I.
+
+## STM32 required flags ##
+CFLAGS += -mlittle-endian -mcpu=cortex-m0 -march=armv6-m -mthumb -mthumb-interwork
+#CFLAGS += --specs=nosys.specs #Some issue with newlib includes related to _exit() causes the compiler to throw errors without this. I suspect the stm32 CMSIS package has includes to replace certain standard C implementations, but for now we will use this semihosting config option.
+
+## Optional configuration flags ##
+
+#I like the idea of consistent fn call frames, but I have no idea whether to use
+# -mapcs-frame for ARM Proc call std or -mtpcs-frame for Thumb Proc call std
+#CFLAGS += -mapcs-frame 
+#CFLAGS += -mtpcs-frame
+#CFLAGS += -Os #Optimize for space, not needed rn
+CFLAGS += -ffreestanding -nostdlib
+#####################################################################################
+
+OBJS = $(SRCS:.c=.o)
+
+.PHONY: project
+
+all: project
+
+%.o : %.c
+	$(CC) $(CFLAGS) -c -o $@ $^
+
+asm: $(OBJS)
+
+project: $(PROJECT).elf
+
+$(PROJECT).elf: $(SRCS)
+	$(CC) $(CFLAGS) $^ -o $@
+	$(OBJCOPY) -O ihex $(PROJECT).elf $(PROJECT).hex
+	$(OBJCOPY) -O binary $(PROJECT).elf $(PROJECT).bin
+	$(OBJDUMP) -St $(PROJECT).elf >$(PROJECT).lst
+	$(SIZE) $(PROJECT).elf
+
+clean:
+	rm -f *.o $(PROJECT).elf $(PROJECT).hex $(PROJECT).bin $(PROJECT).lst
+
+flash:
+	st-flash write $(PROJECT).bin 0x08000000

--- a/jmos-stm32-link.ld
+++ b/jmos-stm32-link.ld
@@ -4,4 +4,47 @@
  *
  */
 
+MEMORY
+	{
+		FLASH (rx):  ORIGIN = 0x08000000, LENGTH = 64K
+		SRAM  (wrx): ORIGIN = 0x20000000, LENGTH = 8K
+	}
 
+    _estack = 0x20002000;
+
+SECTIONS
+    {
+        .isr_vector :
+        {
+            . = ALIGN(4);
+            KEEP(*(.isr_vector))            /* Startup code */
+            . = ALIGN(4);
+        } >FLASH
+        
+        .text :
+        {
+            *(.text*)
+            *(.rodata*)
+            . = ALIGN(4);
+            _etext = .;
+        } > FLASH
+
+        .bss (NOLOAD) :
+        {
+            . = ALIGN(4);
+            _sbss = .;
+            *(.bss*)
+            *(COMMON)
+            . = ALIGN(4);
+            _ebss = .;
+        } > SRAM
+
+        .data : AT (_etext)
+        {
+            . = ALIGN(4);
+            _sdata = .;
+            *(.data*)
+            . = ALIGN(4);
+            _edata = .;
+        } > SRAM
+    }

--- a/jmos-stm32-link.ld
+++ b/jmos-stm32-link.ld
@@ -1,0 +1,7 @@
+/*
+ * Linker script to define memory regions and section definitions 
+ * for the stm32F051 discovery platform
+ *
+ */
+
+

--- a/main.c
+++ b/main.c
@@ -1,0 +1,15 @@
+#include <stdbool.h>
+#include <stdlib.h>
+
+void set_led3_on(){
+    //todo
+    return;
+}
+
+int main(){
+    set_led3_on();
+
+    while(true);
+
+    return 0;
+}


### PR DESCRIPTION
Setting up linker script, Makefile, and main.c entry point.

WARNING - `make flash` has NOT been tested. 

Makefile setup to use compiler flags relevent for STM32F0 programming - thumb instructions only, output linker files for checking, use custom linker script, compile as freestanding with no stdlib.

Still missing assembly code to establish the IVT (Interrupt vector table), perform RAM init for C code entry, branch to C code entry.

Linker script still missing RAM configuration for Stack regions and Heap.