### PR TITLE
Filling out linker script with stack and heap definitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,12 @@ SIZE=arm-none-eabi-size
 PROJECT=jmos
 
 ## General compiler flags ##
-CFLAGS = -Wall -Werror -std=c99 -g -Tjmos-stm32-link.ld
+CFLAGS = -Wall -Werror -std=c99 -Tjmos-stm32-link.ld
 CFLAGS += -ffunction-sections -fdata-sections 
 CFLAGS += -I.
 
 ## STM32 required flags ##
-CFLAGS += -mlittle-endian -mcpu=cortex-m0 -march=armv6-m -mthumb -mthumb-interwork
+CFLAGS += -mlittle-endian -mcpu=cortex-m0 -march=armv6-m -mthumb
 #CFLAGS += --specs=nosys.specs #Some issue with newlib includes related to _exit() causes the compiler to throw errors without this. I suspect the stm32 CMSIS package has includes to replace certain standard C implementations, but for now we will use this semihosting config option.
 
 ## Optional configuration flags ##
@@ -29,7 +29,7 @@ OBJS = $(SRCS:.c=.o)
 
 .PHONY: project
 
-all: project
+all: asm project
 
 %.o : %.c
 	$(CC) $(CFLAGS) -c -o $@ $^

--- a/jmos-stm32-link.ld
+++ b/jmos-stm32-link.ld
@@ -10,7 +10,9 @@ MEMORY
 		SRAM  (wrx): ORIGIN = 0x20000000, LENGTH = 8K
 	}
 
-    _estack = 0x20002000;
+    _esram = 0x20002000;
+    PROC_STACK_SIZE = 0x0E00;
+    HEAP_SIZE = 0x0400;
 
 SECTIONS
     {
@@ -29,6 +31,15 @@ SECTIONS
             _etext = .;
         } > FLASH
 
+        .data : AT (_etext)
+        {
+            . = ALIGN(4);
+            _sdata = .;
+            *(.data*)
+            . = ALIGN(4);
+            _edata = .;
+        } > SRAM
+
         .bss (NOLOAD) :
         {
             . = ALIGN(4);
@@ -39,12 +50,35 @@ SECTIONS
             _ebss = .;
         } > SRAM
 
-        .data : AT (_etext)
+        .heap (NOLOAD): /* heap should start right after data and bss in SRAM */
         {
             . = ALIGN(4);
-            _sdata = .;
-            *(.data*)
+            _sheap = .;
+            . = . + HEAP_SIZE;
             . = ALIGN(4);
-            _edata = .;
+            _eheap = .;
         } > SRAM
+
+        .proc_stack (NOLOAD): /* process stack should be fairly large, I think the bulk of SRAM that isn't used for data */
+        {   
+            . = ALIGN(4);
+            _sproc_stack = .;
+            . = . + PROC_STACK_SIZE;
+            . = ALIGN(4);
+            _eproc_stack = .;
+        }
+
+        main_stack_size = _esram - _eproc_stack;
+        .main_stack (NOLOAD): /* stack for OS kernel and ISR handlers, takes up whatever space remains up to the end of SRAM */
+        {
+            . = ALIGN(4);
+            _smain_stack = .;
+            . = . + main_stack_size;
+            . = ALIGN(4);
+            _emain_stack = .;
+        } > SRAM 
+
+        . = _esram;
+
     }
+


### PR DESCRIPTION
Removed debug "-g" flag from Makefile temporarily, was muddying the symbol table
Removed "-thumb-interwork" flag, doesn't make sense to have ARM-thumb interwork on a platform that only supports .thumb1

Add "asm" to "all" list, as I like seeing the .o files when I build, literally the only reason.

Set up definitions for the heap, main_stack, and process_stack in the linker script.
Not sure if the sizes make sense, but that shouldn't matter too much as they can be easily changed in the script.

Took a while to get it right, but judging by the output of jmos.lst (symbol table) when built, the memory space is mapped how I wanted:

```
End of RAM: 0x20002000 +------------------------------+
                       |         Main stack           |
                       +------------------------------+
                       |       Process stack          |
                       |                              |
                       |                              |
                       +------------------------------|
                       |            Heap              |
                       +------------------------------|
                       |              .bss            |
                       +------------------------------+
                       |              .data           |
St. of RAM: 0x20000000 +------------------------------|
```

Based off of these resources:
https://interrupt.memfault.com/blog/how-to-write-linker-scripts-for-firmware

https://www.st.com/resource/en/reference_manual/rm0091-stm32f0x1stm32f0x2stm32f0x8-advanced-armbased-32bit-mcus-stmicroelectronics.pdf

https://github.com/szczys/stm32f0-discovery-basic-template/blob/master/Device/ldscripts/sections_flash.ld

https://sourceware.org/binutils/docs/ld/index.html#SEC_Contents